### PR TITLE
Fixed: Non-owner of the image can edit/delete the image #3

### DIFF
--- a/src/main/java/ImageHoster/controller/ImageController.java
+++ b/src/main/java/ImageHoster/controller/ImageController.java
@@ -125,7 +125,7 @@ public class ImageController {
 
     //The method also receives tags parameter which is a string of all the tags separated by a comma using the annotation @RequestParam
     //The method converts the string to a list of all the tags using findOrCreateTags() method and sets the tags attribute of an image as a list of all the tags
-    @RequestMapping(value = "/editImage", method = RequestMethod.PUT)
+    @RequestMapping(value = "/editImage", method = RequestMethod.POST)
     public String editImageSubmit(@RequestParam("file") MultipartFile file, @RequestParam("imageId") Integer imageId, @RequestParam("tags") String tags, Image updatedImage, HttpSession session) throws IOException {
 
         Image image = imageService.getImage(imageId);
@@ -145,7 +145,7 @@ public class ImageController {
         updatedImage.setDate(new Date());
 
         imageService.updateImage(updatedImage);
-        return "redirect:/images/" + updatedImage.getTitle();
+        return "redirect:/images/" + updatedImage.getId() + "/" + updatedImage.getTitle();
     }
 
 

--- a/src/main/resources/templates/images/edit.html
+++ b/src/main/resources/templates/images/edit.html
@@ -7,7 +7,7 @@
 
 <h1>Edit Image</h1>
 
-<form th:method="put" th:action="@{/editImage(imageId=${image.id})}" enctype="multipart/form-data">
+<form th:method="post" th:action="@{/editImage(imageId=${image.id})}" enctype="multipart/form-data">
 
     <div>Image Title :</div>
     <div>

--- a/src/main/resources/templates/images/image.html
+++ b/src/main/resources/templates/images/image.html
@@ -16,14 +16,14 @@
         <a th:href="@{/editImage(imageId=${image.id})}">Edit</a>
         <!-- Show the edit error if the non owner of the image is trying to edit the image-->
         <!--Uncomment the below code to show the error if the non owner of the image is trying to edit the image-->
-        <!--<div th:if="${editError}">Only the owner of the image can edit the image</div>-->
+        <div th:if="${editError}">Only the owner of the image can edit the image</div>
         <div><br></div>
         <form th:action="@{/deleteImage(imageId=${image.id})}" th:method="delete">
             <input type="submit" value="Delete"/>
         </form>
         <!-- Show the delete error if the non owner of the image is trying to delete the image-->
         <!--Uncomment the below code to show the error if the non owner of the image is trying to delete the image-->
-        <!--<div th:if="${deleteError}">Only the owner of the image can delete the image</div>-->
+        <div th:if="${deleteError}">Only the owner of the image can delete the image</div>
     </div>
 </nav>
 


### PR DESCRIPTION
Issue fixed with following changes:

Image can be edited only by the owner
Image can be deleted only by the owner

There was an issue with the submission of the edited image details which has been fixed

Image.html file update to show the notification during edit and delete for non-owners

[Fixed: Non-owner of the image can edit/delete the image #3](https://github.com/upgrad-edu/Course_4_Assignment/issues/3#issue-377734549)